### PR TITLE
Integrate WebSocket STT engine

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -19,3 +19,4 @@ TRANSCRIPTION_SERVER_EXTERNAL_HOST="localhost"              # string (Host to ru
 TRANSCRIPTION_SERVER_PORT_TCP="5000"                        # int (Port to run the TCP server on)
 TRANSCRIPTION_SERVER_SECRET="your_secret_token"             # string (Secret token to authenticate clients)
 TRANSCRIPTION_SERVER_HEALTHCHECK_PORT="8001"                # int (Port to run the healthcheck server on)
+STT_WS_URL="ws://example.com/stt"                           # string (URL to the external STT WebSocket server)

--- a/Config.py
+++ b/Config.py
@@ -88,6 +88,7 @@ def load_settings() -> Dict[str, Union[str, int, float, bool]]:
         'SECRET_TOKEN': get_variable('TRANSCRIPTION_SERVER_SECRET', "your_secret_token"),
         'HEALTH_CHECK_PORT': get_variable('TRANSCRIPTION_SERVER_HEALTH_CHECK_PORT', 8001, validate_int),
         'PROMETHEUS_PORT': get_variable('TRANSCRIPTION_SERVER_PROMETHEUS_PORT', 2112, validate_int),
+        'STT_WS_URL': get_variable('STT_WS_URL', 'ws://localhost:2700'),
     }
 
     if not valid_config:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ docker run -it --rm --gpus all ubuntu nvidia-smi # Test GPU support
      ```
 
    - Open the `.env` file and configure the necessary environment variables as per your setup.
+   - Set `STT_WS_URL` to point to your external speech-to-text WebSocket endpoint.
 
 3. **Start the Application:**
 
@@ -142,10 +143,10 @@ The transcription pipeline is built using a modular architecture, where each mod
    - **Purpose:** Identifies and isolates segments of the audio stream that contain speech.
    - **Functionality:** Detects speech activity to filter out silent passages, forwarding only relevant audio segments to the transcription model. Uses the same VAD model as WhisperX for enhanced accuracy and operates in a stateless, parallel mode.
 
-5. **Whisper Module**
-   
-   - **Purpose:** Transcribes the buffered audio into text.
-   - **Functionality:** Employs Faster Whisper to convert audio data into text, leveraging batching and word-level timestamps for improved efficiency and accuracy. Processes the 30-second audio buffer and integrates seamlessly with the VAD module's timestamps. This stateless module is designed for single-worker operation to optimize GPU usage.
+5. **WebSocket STT Module**
+
+   - **Purpose:** Sends the buffered audio to an external speech-to-text service over WebSocket.
+   - **Functionality:** Streams the audio buffer to the STT engine defined by `STT_WS_URL` and converts the returned JSON into timestamped text segments. This module replaces the built-in Whisper model when configured.
 
 6. **Confirm Words Module**
    

--- a/m_websocket_stt.py
+++ b/m_websocket_stt.py
@@ -1,0 +1,79 @@
+# m_websocket_stt.py
+import json
+from typing import List, Optional
+
+from websocket import create_connection
+
+from stream_pipeline.data_package import DataPackage, DataPackageController, DataPackagePhase, DataPackageModule, Status
+from stream_pipeline.module_classes import Module, ModuleOptions
+
+import data
+import logger
+
+log = logger.get_logger()
+
+class WebSocket_STT(Module):
+    def __init__(self, ws_url: str = "ws://localhost:2700") -> None:
+        super().__init__(
+            ModuleOptions(
+                use_mutex=True,
+                timeout=5,
+            ),
+            name="WebSocket-STT-Module",
+        )
+        self.ws_url: str = ws_url
+
+    def init_module(self) -> None:
+        pass
+
+    def execute(self, dp: DataPackage[data.AudioData], dpc: DataPackageController, dpp: DataPackagePhase, dpm: DataPackageModule) -> None:
+        if not dp.data:
+            raise Exception("No data found")
+        if dp.data.raw_audio_data is None:
+            raise Exception("No audio data found")
+
+        log.debug("Sending audio data to external STT")
+        try:
+            ws = create_connection(self.ws_url, timeout=self.timeout)
+            ws.send(dp.data.raw_audio_data, opcode=0x2)  # binary
+            message = ws.recv()
+            ws.close()
+        except Exception as e:
+            dpm.status = Status.EXIT
+            dpm.message = f"WebSocket error: {e}"
+            log.error(f"WebSocket error: {e}")
+            return
+
+        try:
+            response = json.loads(message)
+        except json.JSONDecodeError as e:
+            dpm.status = Status.EXIT
+            dpm.message = f"Invalid JSON response: {e}"
+            log.error("Invalid JSON response from STT server")
+            return
+
+        segments: List[data.TextSegment] = []
+        start_offset = dp.data.audio_buffer_start_after or 0.0
+        for seg in response.get("segments", []):
+            words: Optional[List[data.Word]] = None
+            word_items = seg.get("words")
+            if isinstance(word_items, list):
+                words = []
+                for w in word_items:
+                    words.append(
+                        data.Word(
+                            word=w.get("word", ""),
+                            start=float(w.get("start", 0.0)) + start_offset,
+                            end=float(w.get("end", 0.0)) + start_offset,
+                            probability=float(w.get("probability", 1.0)),
+                        )
+                    )
+            ts = data.TextSegment(
+                text=seg.get("text", ""),
+                start=float(seg.get("start", 0.0)) + start_offset,
+                end=float(seg.get("end", 0.0)) + start_offset,
+                words=words,
+            )
+            segments.append(ts)
+
+        dp.data.transcribed_segments = segments

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from StreamServer import Server, Client as StreamClient
 from Client import Client
 from m_convert_audio import Convert_Audio
 from m_create_audio_buffer import Create_Audio_Buffer
-from m_faster_whisper import Faster_Whisper_transcribe
+from m_websocket_stt import WebSocket_STT
 from m_confirm_words import Confirm_Words
 from m_rate_limiter import Rate_Limiter
 from m_vad import VAD
@@ -26,74 +26,6 @@ log = logger.setup_logging()
 start_http_server(8042)
 
 # CreateNsAudioPackage, Load_audio, VAD, Faster_Whisper_transcribe, Local_Agreement
-controllers = [
-    PipelineController(
-        mode=ControllerMode.NOT_PARALLEL,
-        max_workers=1,
-        queue_size=10,
-        name="Create_Audio_Buffer",
-        phases=[
-            PipelinePhase(
-                name="Create_Audio_Buffer",
-                modules=[
-                    Create_Audio_Buffer(
-                        last_n_seconds=30
-                    ),
-                    Rate_Limiter(),
-                ]
-            )
-        ]
-    ),
-    PipelineController(
-        mode=ControllerMode.FIRST_WINS,
-        max_workers=3,
-        queue_size=2,
-        name="AudioPreprocessingController",
-        phases=[
-            PipelinePhase(
-                name="VADPhase",
-                modules=[
-                    Convert_Audio(),
-                    VAD(),
-                ]
-            )
-        ]
-    ),
-    PipelineController(
-        mode=ControllerMode.FIRST_WINS,
-        max_workers=1,
-        queue_size=0,
-        name="MainProcessingController",
-        phases=[
-            PipelinePhase(
-                name="WhisperPhase",
-                modules=[
-                    Faster_Whisper_transcribe(),
-                ]
-            )
-        ]
-    ),
-    PipelineController(
-        mode=ControllerMode.NOT_PARALLEL,
-        max_workers=1,
-        name="OutputController",
-        phases=[
-            PipelinePhase(
-                name="OutputPhase",
-                modules=[
-                    Confirm_Words(
-                        confirm_if_older_then=1.0,
-                        max_confirmed_words=50
-                    ),
-                ]
-            )
-        ]
-    )
-]
-
-pipeline = Pipeline[data.AudioData](controllers, name="WhisperPipeline")
-
-instance = pipeline.register_instance()
 
 # Health check http sever
 app = Flask(__name__)
@@ -112,6 +44,70 @@ def main() -> None:
     STATUS = "starting"
     
     settings = load_settings()
+
+    controllers = [
+        PipelineController(
+            mode=ControllerMode.NOT_PARALLEL,
+            max_workers=1,
+            queue_size=10,
+            name="Create_Audio_Buffer",
+            phases=[
+                PipelinePhase(
+                    name="Create_Audio_Buffer",
+                    modules=[
+                        Create_Audio_Buffer(last_n_seconds=30),
+                        Rate_Limiter(),
+                    ],
+                )
+            ],
+        ),
+        PipelineController(
+            mode=ControllerMode.FIRST_WINS,
+            max_workers=3,
+            queue_size=2,
+            name="AudioPreprocessingController",
+            phases=[
+                PipelinePhase(
+                    name="VADPhase",
+                    modules=[
+                        Convert_Audio(),
+                        VAD(),
+                    ],
+                )
+            ],
+        ),
+        PipelineController(
+            mode=ControllerMode.FIRST_WINS,
+            max_workers=1,
+            queue_size=0,
+            name="MainProcessingController",
+            phases=[
+                PipelinePhase(
+                    name="WhisperPhase",
+                    modules=[
+                        WebSocket_STT(ws_url=str(settings["STT_WS_URL"])),
+                    ],
+                )
+            ],
+        ),
+        PipelineController(
+            mode=ControllerMode.NOT_PARALLEL,
+            max_workers=1,
+            name="OutputController",
+            phases=[
+                PipelinePhase(
+                    name="OutputPhase",
+                    modules=[
+                        Confirm_Words(confirm_if_older_then=1.0, max_confirmed_words=50),
+                    ],
+                )
+            ],
+        ),
+    ]
+
+    pipeline = Pipeline[data.AudioData](controllers, name="WhisperPipeline")
+
+    instance = pipeline.register_instance()
 
     # Start the health http-server (flask) in a new thread.
     webserverthread = threading.Thread(target=app.run, kwargs={'debug': False, 'host': settings["HOST"], 'port': settings["HEALTH_CHECK_PORT"]})

--- a/requirements.txt
+++ b/requirements.txt
@@ -150,3 +150,4 @@ tzdata==2024.2
 urllib3==2.2.3
 Werkzeug==3.0.4
 yarl==1.15.1
+websocket-client==1.7.1


### PR DESCRIPTION
## Summary
- add new `WebSocket_STT` module to send buffered audio to an external service
- load new STT url from `.env` via `Config`
- wire the WebSocket module into the pipeline in `main.py`
- document the new environment variable and module behaviour
- add `websocket-client` dependency

## Testing
- `python3 -m py_compile m_websocket_stt.py main.py Config.py`
- `pip install -q -r requirements.txt` *(fails: unable to access external repo)*

------
https://chatgpt.com/codex/tasks/task_e_688489637ab0832c8dc12c9fb2e00d53